### PR TITLE
Feature/library tidy up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 # built application files
 build
 *.apk
-*.ap_
-app/app.iml
 *.iml
 
 # files for the dex VM
@@ -27,13 +25,12 @@ proguard/
 
 # Intellij project files
 *.iws
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/libraries
 .idea/*
 
 # Gradle directory
 .gradle
+
+gradle/wrapper/gradle-wrapper.properties
 
 # OS
 .DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,0 @@
-#Fri Jun 03 12:36:03 CEST 2016
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/parser/src/main/AndroidManifest.xml
+++ b/parser/src/main/AndroidManifest.xml
@@ -1,10 +1,2 @@
 <manifest
-    package="io.ticofab.androidgpxparser.parser"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <application
-        android:name=".application.ParserApplication"
-        android:allowBackup="true"
-        android:label="@string/app_name"/>
-
-</manifest>
+    package="io.ticofab.androidgpxparser.parser"/>

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/GPXParser.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/GPXParser.java
@@ -16,7 +16,7 @@ import io.ticofab.androidgpxparser.parser.domain.Gpx;
 import io.ticofab.androidgpxparser.parser.domain.Track;
 import io.ticofab.androidgpxparser.parser.domain.TrackPoint;
 import io.ticofab.androidgpxparser.parser.domain.TrackSegment;
-import io.ticofab.androidgpxparser.parser.task.FetchAndParseGpxTask;
+import io.ticofab.androidgpxparser.parser.task.FetchAndParseGPXTask;
 import io.ticofab.androidgpxparser.parser.task.GpxFetchedAndParsed;
 
 public class GPXParser {
@@ -33,7 +33,7 @@ public class GPXParser {
     static final String ns = null;
 
     public void parse(String gpxUrl, GpxFetchedAndParsed listener) {
-        new FetchAndParseGpxTask(gpxUrl, listener).execute();
+        new FetchAndParseGPXTask(gpxUrl, listener).execute();
     }
 
     public Gpx parse(InputStream in) throws XmlPullParserException, IOException {

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/task/FetchAndParseGPXTask.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/task/FetchAndParseGPXTask.java
@@ -13,13 +13,13 @@ import java.net.URL;
 import io.ticofab.androidgpxparser.parser.GPXParser;
 import io.ticofab.androidgpxparser.parser.domain.Gpx;
 
-public class FetchAndParseGpxTask extends AsyncTask<Void, Void, Gpx> {
+public class FetchAndParseGPXTask extends AsyncTask<Void, Void, Gpx> {
 
     final String mGpxUrl;
     final GpxFetchedAndParsed mListener;
     final GPXParser mParser = new GPXParser();
 
-    public FetchAndParseGpxTask(String gpxUrl, GpxFetchedAndParsed listener) {
+    public FetchAndParseGPXTask(String gpxUrl, GpxFetchedAndParsed listener) {
         mGpxUrl = gpxUrl;
         mListener = listener;
     }


### PR DESCRIPTION
The file `FetchAndParseGPXTask` was named `FetchAndParseGpxTask` in the class. Modified this so both were the same and no warning.
Removed the `<application>` tag from the `AndroidManifest.xml`. This was causing issues with application that had their own extended `Application` class and declaration in the manifest