### PR TITLE
Add parsing in track name

### DIFF
--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/GPXParser.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/GPXParser.java
@@ -94,6 +94,7 @@ public class GPXParser {
     // Parses the contents of an entry. If it encounters a title, summary, or link tag, hands them off
     // to their respective "read" methods for processing. Otherwise, skips the tag.
     private Track readTrack(XmlPullParser parser) throws XmlPullParserException, IOException {
+        String trackName = null;
         List<TrackSegment> segments = new ArrayList<>();
         parser.require(XmlPullParser.START_TAG, ns, TAG_TRACK);
         while (parser.next() != XmlPullParser.END_TAG) {
@@ -102,6 +103,9 @@ public class GPXParser {
             }
             String name = parser.getName();
             switch (name) {
+                case TAG_NAME:
+                    trackName = readName(parser);
+                    break;
                 case TAG_SEGMENT:
                     segments.add(readSegment(parser));
                     break;
@@ -112,6 +116,7 @@ public class GPXParser {
         }
         parser.require(XmlPullParser.END_TAG, ns, TAG_TRACK);
         return new Track.Builder()
+                .setTrackName(trackName)
                 .setTrackSegments(segments)
                 .build();
     }

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Track.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Track.java
@@ -5,10 +5,16 @@ import java.util.Collections;
 import java.util.List;
 
 public class Track {
+    private final String mTrackName;
     private final List<TrackSegment> mTrackSegments;
 
     private Track(Builder builder) {
+        mTrackName = builder.mTrackName;
         mTrackSegments = Collections.unmodifiableList(new ArrayList<>(builder.mTrackSegments));
+    }
+
+    public String getTrackName() {
+        return mTrackName;
     }
 
     public List<TrackSegment> getTrackSegments() {
@@ -16,7 +22,13 @@ public class Track {
     }
 
     public static class Builder {
+        private String mTrackName;
         private List<TrackSegment> mTrackSegments;
+
+        public Builder setTrackName(String trackName) {
+            mTrackName = trackName;
+            return this;
+        }
 
         public Builder setTrackSegments(List<TrackSegment> trackSegments) {
             mTrackSegments = trackSegments;


### PR DESCRIPTION
Because most of GPS devices(like GARMIN)
output GPX files within named track.
It's better to parse Track Name in this library.