### PR TITLE
Schema Update (topografix v1.1)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         applicationId "io.ticofab.androidgpxparser"
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:appcompat-v7:25.4.0'
 
     // You should use the commented out line below in your application.
     // We depend on the source directly here so that development is easier.

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.1'
@@ -17,5 +21,9 @@ plugins {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 }

--- a/parser/build.gradle
+++ b/parser/build.gradle
@@ -26,7 +26,7 @@ ext {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         minSdkVersion 9
@@ -49,9 +49,9 @@ dependencies {
     compile 'net.danlew:android.joda:2.9.9'
 
     androidTestCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support:support-annotations:25.3.1'
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestCompile 'com.android.support:support-annotations:26.1.0'
+    androidTestCompile 'com.android.support.test:runner:1.0.1'
+    androidTestCompile 'com.android.support.test:rules:1.0.1'
 }
 
 apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/GPXParser.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/GPXParser.java
@@ -207,6 +207,8 @@ public class GPXParser {
     private Route readRoute(XmlPullParser parser) throws IOException, XmlPullParserException {
         List<RoutePoint> points = new ArrayList<>();
         parser.require(XmlPullParser.START_TAG, ns, TAG_ROUTE);
+        Route.Builder routeBuilder = new Route.Builder();
+
         while (parser.next() != XmlPullParser.END_TAG) {
             if (parser.getEventType() != XmlPullParser.START_TAG) {
                 continue;
@@ -216,13 +218,33 @@ public class GPXParser {
                 case TAG_ROUTE_POINT:
                     points.add(readRoutePoint(parser));
                     break;
+                case TAG_NAME:
+                    routeBuilder.setRouteName(readName(parser));
+                    break;
+                case TAG_DESC:
+                    routeBuilder.setRouteDesc(readDesc(parser));
+                    break;
+                case TAG_CMT:
+                    routeBuilder.setRouteCmt(readCmt(parser));
+                    break;
+                case TAG_SRC:
+                    routeBuilder.setRouteSrc(readString(parser,TAG_SRC));
+                    break;
+                case TAG_LINK:
+                    routeBuilder.setRouteLink(readLink(parser));
+                    break;
+                case TAG_NUMBER:
+                    routeBuilder.setRouteNumber(readNumber(parser));
+                    break;
+                case TAG_TYPE:
+                    routeBuilder.setRouteType(readString(parser,TAG_TYPE));
                 default:
                     skip(parser);
                     break;
             }
         }
         parser.require(XmlPullParser.END_TAG, ns, TAG_ROUTE);
-        return new Route.Builder()
+        return routeBuilder
                 .setRoutePoints(points)
                 .build();
     }

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Link.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Link.java
@@ -1,0 +1,47 @@
+package io.ticofab.androidgpxparser.parser.domain;
+
+/**
+ * Created by Stu Stirling on 04/10/2017.
+ */
+
+public class Link {
+
+    private final String mLinkText;
+    private final String mLinkType;
+
+    private Link(Builder builder) {
+        mLinkText = builder.mLinkText;
+        mLinkType = builder.mLinkType;
+    }
+
+    public String getText() {
+        return mLinkText;
+    }
+
+    public String getType() {
+        return mLinkType;
+    }
+
+    public static class Builder {
+        private String mLinkText;
+        private String mLinkType;
+
+        public Builder() {
+
+        }
+
+        public Builder setLinkText(String linkText) {
+            mLinkText = linkText;
+            return this;
+        }
+
+        public Builder setLinkType(String linkType ) {
+            mLinkType = linkType;
+            return this;
+        }
+
+        public Link build(){
+            return new Link(this);
+        }
+    }
+}

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Route.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Route.java
@@ -6,20 +6,104 @@ import java.util.List;
 
 public class Route {
     private final List<RoutePoint> mRoutePoints;
+    private final String mRouteName;
+    private final String mRouteDesc;
+    private final String mRouteCmt;
+    private final String mRouteSrc;
+    private final Integer mRouteNumber;
+    private final Link mRouteLink;
+    private final String mRouteType;
 
     private Route(Builder builder) {
         mRoutePoints = Collections.unmodifiableList(new ArrayList<>(builder.mRoutePoints));
+        mRouteName = builder.mRouteName;
+        mRouteDesc = builder.mRouteDesc;
+        mRouteCmt = builder.mRouteCmt;
+        mRouteSrc = builder.mRouteSrc;
+        mRouteNumber = builder.mRouteNumber;
+        mRouteLink = builder.mRouteLink;
+        mRouteType = builder.mRouteType;
     }
 
     public List<RoutePoint> getRoutePoints() {
         return mRoutePoints;
     }
 
+    public String getRouteName() {
+        return mRouteName;
+    }
+
+    public String getRouteDesc() {
+        return mRouteDesc;
+    }
+
+    public String getRouteCmt() {
+        return mRouteCmt;
+    }
+
+    public String getRouteSrc() {
+        return mRouteSrc;
+    }
+
+    public Integer getRouteNumber() {
+        return mRouteNumber;
+    }
+
+    public Link getRouteLink() {
+        return mRouteLink;
+    }
+
+    public String getRouteType() {
+        return mRouteType;
+    }
+
     public static class Builder {
         private List<RoutePoint> mRoutePoints;
+        private String mRouteName;
+        private String mRouteDesc;
+        private String mRouteCmt;
+        private String mRouteSrc;
+        private Integer mRouteNumber;
+        private Link mRouteLink;
+        private String mRouteType;
 
         public Builder setRoutePoints(List<RoutePoint> routePoints) {
             mRoutePoints = routePoints;
+            return this;
+        }
+
+        public Builder setRouteName(String mRouteName) {
+            this.mRouteName = mRouteName;
+            return this;
+        }
+
+        public Builder setRouteDesc(String mRouteDesc) {
+            this.mRouteDesc = mRouteDesc;
+            return this;
+        }
+
+        public Builder setRouteCmt(String mRouteCmt) {
+            this.mRouteCmt = mRouteCmt;
+            return this;
+        }
+
+        public Builder setRouteSrc(String mRouteSrc) {
+            this.mRouteSrc = mRouteSrc;
+            return this;
+        }
+
+        public Builder setRouteNumber(Integer mRouteNumber) {
+            this.mRouteNumber = mRouteNumber;
+            return this;
+        }
+
+        public Builder setRouteLink(Link mRouteLink) {
+            this.mRouteLink = mRouteLink;
+            return this;
+        }
+
+        public Builder setRouteType(String mRouteType) {
+            this.mRouteType = mRouteType;
             return this;
         }
 

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Track.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Track.java
@@ -7,14 +7,50 @@ import java.util.List;
 public class Track {
     private final String mTrackName;
     private final List<TrackSegment> mTrackSegments;
+    private final String mTrackDesc;
+    private final String mTrackCmt;
+    private final String mTrackSrc;
+    private final Integer mTrackNumber;
+    private final Link mTrackLink;
+    private final String mTrackType;
 
     private Track(Builder builder) {
         mTrackName = builder.mTrackName;
+        mTrackDesc = builder.mTrackDesc;
+        mTrackCmt = builder.mTrackCmt;
+        mTrackSrc = builder.mTrackSrc;
+        mTrackNumber = builder.mTrackNumber;
         mTrackSegments = Collections.unmodifiableList(new ArrayList<>(builder.mTrackSegments));
+        mTrackLink = builder.mTrackLink;
+        mTrackType = builder.mTrackType;
     }
 
     public String getTrackName() {
         return mTrackName;
+    }
+
+    public String getTrackDesc() {
+        return mTrackDesc;
+    }
+
+    public String getTrackCmt() {
+        return mTrackCmt;
+    }
+
+    public String getTrackSrc() {
+        return mTrackSrc;
+    }
+
+    public Integer getTrackNumber() {
+        return mTrackNumber;
+    }
+
+    public Link getTrackLink() {
+        return mTrackLink;
+    }
+
+    public String getTrackType() {
+        return mTrackType;
     }
 
     public List<TrackSegment> getTrackSegments() {
@@ -24,9 +60,20 @@ public class Track {
     public static class Builder {
         private String mTrackName;
         private List<TrackSegment> mTrackSegments;
+        private String mTrackDesc;
+        private String mTrackCmt;
+        private String mTrackSrc;
+        private Integer mTrackNumber;
+        private Link mTrackLink;
+        private String mTrackType;
 
         public Builder setTrackName(String trackName) {
             mTrackName = trackName;
+            return this;
+        }
+
+        public Builder setTrackDesc(String trackDesc) {
+            mTrackDesc = trackDesc;
             return this;
         }
 
@@ -35,8 +82,35 @@ public class Track {
             return this;
         }
 
+        public Builder setTrackCmt(String trackCmt) {
+            mTrackCmt = trackCmt;
+            return this;
+        }
+
+        public Builder setTrackSrc(String trackSrc) {
+            mTrackSrc = trackSrc;
+            return this;
+        }
+
+        public Builder setTrackNumber(Integer trackNumber) {
+            mTrackNumber = trackNumber;
+            return this;
+        }
+
+        public Builder setTrackLink(Link link) {
+            mTrackLink = link;
+            return this;
+        }
+
+        public Builder setTrackType(String type) {
+            mTrackType = type;
+            return this;
+        }
+
         public Track build() {
             return new Track(this);
         }
+
+
     }
 }


### PR DESCRIPTION
I had a requirement where I needed more of the `trk` attributes than was currently being parsed. 

I also noticed issue #14 required more attributes on the `rte` type so I added those at the same time.

The link to the schema I followed is [here](http://www.topografix.com/GPX/1/1/)

I couldn't find a GPX file that contained all of these new attributes so I was unable to test it. If someone could provide one to me or create me one that I can test against that would be great.

Existing tests still run successfully. Be great if we could get this released asap as I need it for a project. I would normally include it as a project reference but the plugins this library uses stops me from doing so.