### PR TITLE
Removed incorrect logging

### DIFF
--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/GPXParser.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/GPXParser.java
@@ -97,7 +97,6 @@ public class GPXParser {
             }
             String name = parser.getName();
             // Starts by looking for the entry tag
-            Log.d("GPXParser","Parsing TAG: "+name);
             switch (name) {
                 case TAG_METADATA:
                     builder.setMetadata(readMetadata(parser));


### PR DESCRIPTION
After the changes I made to parse the metadata I had left in a log that was outputting every tag it read. This has now been removed.