### PR TITLE
Fix and extend metadata parsing

### DIFF
--- a/parser/src/androidTest/assets/metadata-full.gpx
+++ b/parser/src/androidTest/assets/metadata-full.gpx
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" creator="Sports Tracker" version="1.1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd">
+
+  <metadata>
+    <name>metadata-full</name>
+    <desc>Full metadata test</desc>
+    <author>
+      <name>John Doe</name>
+      <email id="john.doe" domain="example.org"/>
+      <link href="www.example.org">
+        <text>Example Org.</text>
+        <type>text/html</type>
+      </link>
+    </author>
+    <copyright author="Jane Doe">
+      <year>2019</year>
+      <license>https://www.apache.org/licenses/LICENSE-2.0.txt</license>
+    </copyright>
+    <link href="www.example.org"/>
+    <time>2019-04-04T07:00:00+03:00</time>
+    <keywords>metadata, test</keywords>
+    <bounds maxlat="70.23250000" maxlon="31.63944444" minlat="59.93305556" minlon="20.78944444"/>
+  </metadata>
+
+</gpx>

--- a/parser/src/androidTest/assets/metadata-minimal.gpx
+++ b/parser/src/androidTest/assets/metadata-minimal.gpx
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" creator="Sports Tracker" version="1.1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd">
+
+  <metadata>
+    <author>
+    </author>
+    <copyright author="Jane Doe" />
+  </metadata>
+
+</gpx>

--- a/parser/src/androidTest/java/io/ticofab/androidgpxparser/parser/GPXParserTest.java
+++ b/parser/src/androidTest/java/io/ticofab/androidgpxparser/parser/GPXParserTest.java
@@ -6,6 +6,7 @@ import android.support.test.runner.AndroidJUnit4;
 
 import net.danlew.android.joda.JodaTimeAndroid;
 
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -14,10 +15,17 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 import java.io.InputStream;
 
+import io.ticofab.androidgpxparser.parser.domain.Author;
+import io.ticofab.androidgpxparser.parser.domain.Copyright;
+import io.ticofab.androidgpxparser.parser.domain.Email;
 import io.ticofab.androidgpxparser.parser.domain.Gpx;
+import io.ticofab.androidgpxparser.parser.domain.Link;
+import io.ticofab.androidgpxparser.parser.domain.Metadata;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @MediumTest
 @RunWith(AndroidJUnit4.class)
@@ -70,5 +78,68 @@ public class GPXParserTest {
         assertEquals(1, gpx.getTracks().size());
     }
 
+    @Test
+    public void testFullMetadataParsing() throws IOException, XmlPullParserException {
+        InputStream input = InstrumentationRegistry.getContext().getAssets().open("metadata-full.gpx");
+        Gpx gpx = new GPXParser().parse(input);
 
+        final Metadata metadata = gpx.getMetadata();
+        // Name
+        assertEquals("metadata-full", metadata.getName());
+        assertEquals("Full metadata test", metadata.getDesc());
+
+        // Author
+        final Author author = metadata.getAuthor();
+        assertEquals("John Doe", author.getName());
+
+        // Author email
+        final Email email = author.getEmail();
+        assertEquals("john.doe", email.getId());
+        assertEquals("example.org", email.getDomain());
+
+        // Author link
+        final Link authorLink = author.getLink();
+        assertEquals("www.example.org", authorLink.getHref());
+        assertEquals("Example Org.", authorLink.getText());
+        assertEquals("text/html", authorLink.getType());
+
+        // Copyright
+        final Copyright copyright = metadata.getCopyright();
+        assertEquals("Jane Doe", copyright.getAuthor());
+        assertEquals("2019", copyright.getYear());
+        assertEquals("https://www.apache.org/licenses/LICENSE-2.0.txt", copyright.getLicense());
+
+        // Link
+        final Link link = metadata.getLink();
+        assertEquals("www.example.org", link.getHref());
+        assertNull(link.getText());
+        assertNull(link.getType());
+
+        // Time
+        final DateTime expectedTime = DateTime.parse("2019-04-04T07:00:00+03:00");
+        assertTrue(expectedTime.isEqual(metadata.getTime()));
+
+        // Keywords
+        assertEquals("metadata, test", metadata.getKeywords());
+    }
+
+    @Test
+    public void testMinimalMetadataParsing() throws IOException, XmlPullParserException {
+        InputStream input = InstrumentationRegistry.getContext().getAssets().open("metadata-minimal.gpx");
+        Gpx gpx = new GPXParser().parse(input);
+
+        final Metadata metadata = gpx.getMetadata();
+
+        // Author
+        final Author author = metadata.getAuthor();
+        assertNull(author.getName());
+        assertNull(author.getEmail());
+        assertNull(author.getLink());
+
+        // Copyright
+        final Copyright copyright = metadata.getCopyright();
+        assertEquals("Jane Doe", copyright.getAuthor());
+        assertNull(copyright.getYear());
+        assertNull(copyright.getLicense());
+    }
 }

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/GPXParser.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/GPXParser.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.ticofab.androidgpxparser.parser.domain.Bounds;
+import io.ticofab.androidgpxparser.parser.domain.Copyright;
 import io.ticofab.androidgpxparser.parser.domain.Gpx;
 import io.ticofab.androidgpxparser.parser.domain.Link;
 import io.ticofab.androidgpxparser.parser.domain.Metadata;
@@ -60,6 +61,8 @@ public class GPXParser {
     static private final String TAG_MAX_LAT = "maxlat";
     static private final String TAG_MAX_LON = "maxlon";
     static private final String TAG_HREF = "href";
+    static private final String TAG_YEAR = "year";
+    static private final String TAG_LICENSE = "license";
 
     static private final String ns = null;
 
@@ -347,7 +350,7 @@ public class GPXParser {
                     metadataBuilder.setAuthor(readString(parser, TAG_AUTHOR));
                     break;
                 case TAG_COPYRIGHT:
-                    metadataBuilder.setCopyright(readString(parser, TAG_COPYRIGHT));
+                    metadataBuilder.setCopyright(readCopyright(parser));
                     break;
                 case TAG_LINK:
                     metadataBuilder.setLink(readLink(parser));
@@ -371,6 +374,33 @@ public class GPXParser {
         }
         parser.require(XmlPullParser.END_TAG, ns, TAG_METADATA);
         return metadataBuilder.build();
+    }
+
+    private Copyright readCopyright(XmlPullParser parser) throws XmlPullParserException, IOException {
+        parser.require(XmlPullParser.START_TAG, ns, TAG_COPYRIGHT);
+
+        Copyright.Builder copyrightBuilder = new Copyright.Builder();
+        copyrightBuilder.setAuthor(parser.getAttributeValue(null, TAG_AUTHOR));
+
+        while (loopMustContinue(parser.next())) {
+            if (parser.getEventType() != XmlPullParser.START_TAG) {
+                continue;
+            }
+            String name = parser.getName();
+            switch (name) {
+                case TAG_YEAR:
+                    copyrightBuilder.setYear(readString(parser, TAG_YEAR));
+                    break;
+                case TAG_LICENSE:
+                    copyrightBuilder.setLicense(readString(parser, TAG_LICENSE));
+                    break;
+                default:
+                    skip(parser);
+                    break;
+            }
+        }
+        parser.require(XmlPullParser.END_TAG, ns, TAG_COPYRIGHT);
+        return copyrightBuilder.build();
     }
 
     private WayPoint readWayPoint(XmlPullParser parser) throws XmlPullParserException, IOException {

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/GPXParser.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/GPXParser.java
@@ -12,8 +12,10 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.ticofab.androidgpxparser.parser.domain.Author;
 import io.ticofab.androidgpxparser.parser.domain.Bounds;
 import io.ticofab.androidgpxparser.parser.domain.Copyright;
+import io.ticofab.androidgpxparser.parser.domain.Email;
 import io.ticofab.androidgpxparser.parser.domain.Gpx;
 import io.ticofab.androidgpxparser.parser.domain.Link;
 import io.ticofab.androidgpxparser.parser.domain.Metadata;
@@ -63,6 +65,9 @@ public class GPXParser {
     static private final String TAG_HREF = "href";
     static private final String TAG_YEAR = "year";
     static private final String TAG_LICENSE = "license";
+    static private final String TAG_EMAIL = "email";
+    static private final String TAG_ID = "id";
+    static private final String TAG_DOMAIN = "domain";
 
     static private final String ns = null;
 
@@ -347,7 +352,7 @@ public class GPXParser {
                     metadataBuilder.setDesc(readDesc(parser));
                     break;
                 case TAG_AUTHOR:
-                    metadataBuilder.setAuthor(readString(parser, TAG_AUTHOR));
+                    metadataBuilder.setAuthor(readAuthor(parser));
                     break;
                 case TAG_COPYRIGHT:
                     metadataBuilder.setCopyright(readCopyright(parser));
@@ -374,6 +379,48 @@ public class GPXParser {
         }
         parser.require(XmlPullParser.END_TAG, ns, TAG_METADATA);
         return metadataBuilder.build();
+    }
+
+    private Author readAuthor(XmlPullParser parser) throws XmlPullParserException, IOException {
+        Author.Builder authorBuilder = new Author.Builder();
+
+        parser.require(XmlPullParser.START_TAG, ns, TAG_AUTHOR);
+        while (loopMustContinue(parser.next())) {
+            if (parser.getEventType() != XmlPullParser.START_TAG) {
+                continue;
+            }
+            String name = parser.getName();
+            switch (name) {
+                case TAG_NAME:
+                    authorBuilder.setName(readString(parser, TAG_NAME));
+                    break;
+                case TAG_EMAIL:
+                    authorBuilder.setEmail(readEmail(parser));
+                    break;
+                case TAG_LINK:
+                    authorBuilder.setLink(readLink(parser));
+                    break;
+                default:
+                    skip(parser);
+                    break;
+            }
+        }
+        parser.require(XmlPullParser.END_TAG, ns, TAG_AUTHOR);
+        return authorBuilder.build();
+    }
+
+    private Email readEmail(XmlPullParser parser) throws IOException, XmlPullParserException {
+        parser.require(XmlPullParser.START_TAG, ns, TAG_EMAIL);
+
+        Email.Builder emailBuilder = new Email.Builder();
+        emailBuilder.setId(parser.getAttributeValue(null, TAG_ID));
+        emailBuilder.setDomain(parser.getAttributeValue(null, TAG_DOMAIN));
+
+        // Email tag is self closed, advance the parser to next event
+        parser.next();
+
+        parser.require(XmlPullParser.END_TAG, ns, TAG_EMAIL);
+        return emailBuilder.build();
     }
 
     private Copyright readCopyright(XmlPullParser parser) throws XmlPullParserException, IOException {

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Author.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Author.java
@@ -1,0 +1,51 @@
+package io.ticofab.androidgpxparser.parser.domain;
+
+public class Author {
+
+    private final String mName;
+    private final Email mEmail;
+    private final Link mLink;
+
+    private Author(Builder builder) {
+        this.mName = builder.mName;
+        this.mEmail = builder.mEmail;
+        this.mLink = builder.mLink;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public Email getEmail() {
+        return mEmail;
+    }
+
+    public Link getLink() {
+        return mLink;
+    }
+
+    public static class Builder {
+        private String mName;
+        private Email mEmail;
+        private Link mLink;
+
+        public Builder setName(String mName) {
+            this.mName = mName;
+            return this;
+        }
+
+        public Builder setEmail(Email mEmail) {
+            this.mEmail = mEmail;
+            return this;
+        }
+
+        public Builder setLink(Link mLink) {
+            this.mLink = mLink;
+            return this;
+        }
+
+        public Author build() {
+            return new Author(this);
+        }
+    }
+}

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Copyright.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Copyright.java
@@ -1,0 +1,51 @@
+package io.ticofab.androidgpxparser.parser.domain;
+
+public class Copyright {
+
+    private final String mAuthor;
+    private final String mYear;
+    private final String mLicense;
+
+    private Copyright(Builder builder) {
+        this.mAuthor = builder.mAuthor;
+        this.mYear = builder.mYear;
+        this.mLicense = builder.mLicense;
+    }
+
+    public String getAuthor() {
+        return mAuthor;
+    }
+
+    public String getYear() {
+        return mYear;
+    }
+
+    public String getLicense() {
+        return mLicense;
+    }
+
+    public static class Builder {
+        private String mAuthor;
+        private String mYear;
+        private String mLicense;
+
+        public Builder setAuthor(String mAuthor) {
+            this.mAuthor = mAuthor;
+            return this;
+        }
+
+        public Builder setYear(String mYear) {
+            this.mYear = mYear;
+            return this;
+        }
+
+        public Builder setLicense(String mLicense) {
+            this.mLicense = mLicense;
+            return this;
+        }
+
+        public Copyright build() {
+            return new Copyright(this);
+        }
+    }
+}

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Email.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Email.java
@@ -1,0 +1,39 @@
+package io.ticofab.androidgpxparser.parser.domain;
+
+public class Email {
+
+    private String mId;
+    private String mDomain;
+
+    private Email(Builder builder) {
+        this.mId = builder.mId;
+        this.mDomain = builder.mDomain;
+    }
+
+    public String getId() {
+        return mId;
+    }
+
+    public String getDomain() {
+        return mDomain;
+    }
+
+    public static class Builder {
+        private String mId;
+        private String mDomain;
+
+        public Builder setId(String mId) {
+            this.mId = mId;
+            return this;
+        }
+
+        public Builder setDomain(String mDomain) {
+            this.mDomain = mDomain;
+            return this;
+        }
+
+        public Email build() {
+            return new Email(this);
+        }
+    }
+}

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Metadata.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Metadata.java
@@ -7,7 +7,7 @@ public class Metadata {
     private final String mName;
     private final String mDesc;
     private final String mAuthor;
-    private final String mCopyright;
+    private final Copyright mCopyright;
     private final Link mLink;
     private final DateTime mTime;
     private final String mKeywords;
@@ -38,7 +38,7 @@ public class Metadata {
         return mAuthor;
     }
 
-    public String getCopyright() {
+    public Copyright getCopyright() {
         return mCopyright;
     }
 
@@ -66,7 +66,7 @@ public class Metadata {
         private String mName;
         private String mDesc;
         private String mAuthor;
-        private String mCopyright;
+        private Copyright mCopyright;
         private Link mLink;
         private DateTime mTime;
         private String mKeywords;
@@ -88,7 +88,7 @@ public class Metadata {
             return this;
         }
 
-        public Builder setCopyright(String mCopyright) {
+        public Builder setCopyright(Copyright mCopyright) {
             this.mCopyright = mCopyright;
             return this;
         }

--- a/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Metadata.java
+++ b/parser/src/main/java/io/ticofab/androidgpxparser/parser/domain/Metadata.java
@@ -6,7 +6,7 @@ public class Metadata {
 
     private final String mName;
     private final String mDesc;
-    private final String mAuthor;
+    private final Author mAuthor;
     private final Copyright mCopyright;
     private final Link mLink;
     private final DateTime mTime;
@@ -34,7 +34,7 @@ public class Metadata {
         return mDesc;
     }
 
-    public String getAuthor() {
+    public Author getAuthor() {
         return mAuthor;
     }
 
@@ -65,7 +65,7 @@ public class Metadata {
     public static class Builder {
         private String mName;
         private String mDesc;
-        private String mAuthor;
+        private Author mAuthor;
         private Copyright mCopyright;
         private Link mLink;
         private DateTime mTime;
@@ -83,7 +83,7 @@ public class Metadata {
             return this;
         }
 
-        public Builder setAuthor(String mAuthor) {
+        public Builder setAuthor(Author mAuthor) {
             this.mAuthor = mAuthor;
             return this;
         }


### PR DESCRIPTION
Metadata parsing introduced in version 1.3.0 didn't follow the [Topografix GPX 1.1](http://www.topografix.com/GPX/1/1/) specification exactly. This PR updates the following metadata related issues:

1. Parse year and license subtags for metadata copyright tag
2. Parse name, email and link subtags for metadata author tag
3. Add test cases for metadata parsing